### PR TITLE
Allows the token and application to be set via environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY package.json package.json
 RUN npm install --production
 RUN npm cache clean
 COPY index.js /usr/src/app/index.js
+COPY ./docker-entrypoint.sh /
 
-ENTRYPOINT ["/usr/src/app/index.js"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD []

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/usr/src/app/index.js -t $LOGZIO_TOKEN -j -a application=$LOGZIO_APPLICATION


### PR DESCRIPTION
This change allows to set the token and app via environment variables. This is helpful with docker-compose where we could use environment variables to set the token and application.

```
  logz:
    image: logzio/logzio-docker
    volumes:
    - "/var/run/docker.sock:/var/run/docker.sock"
    environment:
      LOGZIO_TOKEN: default-token
      LOGZIO_APPLICATION: default-application
    env_file: .env # overrides defaults
```
