### PR TITLE
Propagate timestamp from docker-loghose

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function start(opts) {
             else {
               obj.logzio_codec = 'plain';
             }
+            obj['@timestamp'] = (new Date(obj.time)).toISOString();
             type = 'docker_logs';
         }
         else if (obj.type) {


### PR DESCRIPTION
... to logzio-nodejs so that resulting log entry will have correct
timestamp. This is needed to order log entries properly in Kibana.