### PR TITLE
add docker labels to all logs shipped to LogzIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ You can also set your Logz.io token and zone with the following environment vari
 * `LOGZIO_TOKEN = <token>`
 * `LOGZIO_ZONE = <zone> `
 
+To enrich all log events published to Logz.io with labels that are set on the container use the following options:
+
+* `--addLabels`: toggle to enable 'adding of labels' to each log entry.
+* `--labelsKey <field>`: Place all label fields under this key. ie: `--labelsKey labels` would result in labels.mydockerlabel as a fieldname in Logz.io. By default the labels will be placed directly at the root of the object.
+* `--labelsMatch REGEXP`: Only add labels if the label name matches the given REGEXP.
+
 ### Running container in a restricted environment.
 Some environments(such as Google Compute Engine) does not allow to access the docker socket without special privileges. You will get EACCES(`Error: read EACCES`) error if you try to run the container.
 To run the container in such environments add --privileged to the `docker run` command.

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ function cli() {
             '                         [-i STATSINTERVAL] [-a KEY=VALUE] [-z us|eu]\n' +
             '                         [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
             '                         [--skipByImage REGEXP] [--skipByName REGEXP]\n' +
+            '                         [--addLabels] [--labelsKey keyname] [--labelsMatch REGEXP]' +
             '                         [--help]');
 
         process.exit(1);

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "author": "Ran Ramati <ran@logz.io>",
   "license": "MIT",
   "dependencies": {
-    "docker-allcontainers": "0.6.1",
+    "docker-allcontainers": "0.8.0",
     "docker-event-log": "0.1.3",
-    "docker-loghose": "1.4.0",
+    "docker-loghose": "1.6.4",
     "docker-stats": "0.7.2",
     "dockerode": "2.4.3",
     "minimist": "1.2.0",


### PR DESCRIPTION
Updated version of docker-loghose allows docker labels to be added to every logentry being send to LogzIO.