### PR TITLE
Update logzio-nodejs dependency 

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function getOrCreateLogger(type, opts) {
             protocol: opts.secure ? 'https' : 'http',
             type: type,
             bufferSize: 1000,
-            host: opts.zone === 'eu' ? 'listener-eu.logz.io' : '' // US is the default value
+            host: opts.zone === 'eu' ? 'listener-eu.logz.io' : 'listener.logz.io'
         }
 
         // Allow override to a specific logzio endpoint

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dockerode": "2.4.3",
     "minimist": "1.2.0",
     "through2": "2.0.3",
-    "logzio-nodejs": "1.5.0",
+    "logzio-nodejs": "1.0.3",
     "is-json": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dockerode": "2.4.3",
     "minimist": "1.2.0",
     "through2": "2.0.3",
-    "logzio-nodejs": "0.4.2",
+    "logzio-nodejs": "1.5.0",
     "is-json": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logzio-docker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Forward all logs from all running docker containers to Logz.io",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The old version does not allow overiding the `type` attribute, which we needed to do.
Thanks